### PR TITLE
chore(quickstart): add missing DMN screenshot

### DIFF
--- a/lib/quickstart.js
+++ b/lib/quickstart.js
@@ -65,7 +65,7 @@ module.exports = async function startScreenshotBatch() {
       await modeler.click('[data-action="replace"]');
       await modeler.mouseOver('[data-id="replace-with-service-task"]');
 
-      await modeler.annotate('.djs-context-pad.open', '1. Select <b>activity</b>\\n2. Click <b>wrench icon</b> and change type to <b>Service Task</b>', annotationOptions.right);
+      await modeler.annotate('[data-action="replace"]', '1. Select <b>activity</b>\\n2. Click <b>wrench icon</b> and change type to <b>Service Task</b>', annotationOptions.right);
 
       await modeler.takeScreenshot(filepath);
     }
@@ -535,6 +535,26 @@ module.exports = async function startScreenshotBatch() {
       modeler = await createModeler(diagramPaths, config);
 
       await modeler.click('[data-container-id="approve-payment"] .drill-down-overlay');
+
+      await modeler.takeScreenshot(filepath);
+    }
+  );
+
+  await triggerScreenshot('camunda-docs-static/get-started/content/quick-start/img/modeler-dmn6.png',
+    async (filepath) => {
+      const diagramPaths = [ path.join(__dirname, './fixtures/dmn/quickstart/step4.2.dmn') ],
+            config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
+
+      modeler = await createModeler(diagramPaths, config);
+
+      await modeler.click('[data-container-id="approve-payment"] .drill-down-overlay');
+      await modeler.click('.app-icon-deploy');
+
+      // Prepare input
+      await modeler.app.client.waitForVisible('#deployment\\.name')
+        .doubleClick('#deployment\\.name')
+        .keys('Backspace')
+        .setValue('#deployment\\.name', 'Payment Retrieval Decision');
 
       await modeler.takeScreenshot(filepath);
     }


### PR DESCRIPTION
Adds suggestion by Volker for https://github.com/camunda/camunda-docs-static/pull/144 and a missing Screenshot for the quick-start guide.

related to CAM-13250