### PR TITLE
fix: correct modeler screenshot location

### DIFF
--- a/lib/modelingGuidance.js
+++ b/lib/modelingGuidance.js
@@ -9,7 +9,7 @@ module.exports = function startScreenshotBatch() {
 
   return [
 
-    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/rules/img/called-element/wrong.png', async (filepath) => {
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/called-element/wrong.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/called-element/wrong.bpmn') ],
             config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
 
@@ -26,7 +26,7 @@ module.exports = function startScreenshotBatch() {
       return modeler;
     }),
 
-    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/rules/img/called-element/right.png', async (filepath) => {
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/called-element/right.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/called-element/right.bpmn') ],
             config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
 
@@ -43,7 +43,7 @@ module.exports = function startScreenshotBatch() {
       return modeler;
     }),
 
-    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/rules/img/element-type/wrong.png', async (filepath) => {
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/element-type/wrong.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/element-type/wrong.bpmn') ],
             config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
 
@@ -58,7 +58,7 @@ module.exports = function startScreenshotBatch() {
       return modeler;
     }),
 
-    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/rules/img/element-type/right.png', async (filepath) => {
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/element-type/right.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/element-type/right.bpmn') ],
             config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
 
@@ -73,7 +73,7 @@ module.exports = function startScreenshotBatch() {
       return modeler;
     }),
 
-    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/rules/img/error-reference/wrong-no-error-reference.png', async (filepath) => {
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/error-reference/wrong-no-error-reference.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/error-reference/wrong-no-error-reference.bpmn') ],
             config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
 
@@ -90,7 +90,7 @@ module.exports = function startScreenshotBatch() {
       return modeler;
     }),
 
-    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/rules/img/error-reference/wrong-no-error-code.png', async (filepath) => {
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/error-reference/wrong-no-error-code.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/error-reference/wrong-no-error-code.bpmn') ],
             config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
 
@@ -107,7 +107,7 @@ module.exports = function startScreenshotBatch() {
       return modeler;
     }),
 
-    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/rules/img/error-reference/right.png', async (filepath) => {
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/error-reference/right.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/error-reference/right.bpmn') ],
             config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
 
@@ -124,7 +124,7 @@ module.exports = function startScreenshotBatch() {
       return modeler;
     }),
 
-    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/rules/img/escalation-reference/wrong-no-escalation-reference.png', async (filepath) => {
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/escalation-reference/wrong-no-escalation-reference.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/escalation-reference/wrong-no-escalation-reference.bpmn') ],
             config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
 
@@ -141,7 +141,7 @@ module.exports = function startScreenshotBatch() {
       return modeler;
     }),
 
-    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/rules/img/escalation-reference/wrong-no-escalation-code.png', async (filepath) => {
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/escalation-reference/wrong-no-escalation-code.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/escalation-reference/wrong-no-escalation-code.bpmn') ],
             config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
 
@@ -158,7 +158,7 @@ module.exports = function startScreenshotBatch() {
       return modeler;
     }),
 
-    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/rules/img/escalation-reference/right.png', async (filepath) => {
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/escalation-reference/right.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/escalation-reference/right.bpmn') ],
             config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
 
@@ -175,7 +175,7 @@ module.exports = function startScreenshotBatch() {
       return modeler;
     }),
 
-    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/rules/img/feel/wrong.png', async (filepath) => {
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/feel/wrong.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/feel/wrong.bpmn') ],
             config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
 
@@ -192,7 +192,7 @@ module.exports = function startScreenshotBatch() {
       return modeler;
     }),
 
-    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/rules/img/feel/right.png', async (filepath) => {
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/feel/right.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/feel/right.bpmn') ],
             config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
 
@@ -209,7 +209,7 @@ module.exports = function startScreenshotBatch() {
       return modeler;
     }),
 
-    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/rules/img/message-reference/wrong-no-message-reference.png', async (filepath) => {
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/message-reference/wrong-no-message-reference.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/message-reference/wrong-no-message-reference.bpmn') ],
             config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
 
@@ -226,7 +226,7 @@ module.exports = function startScreenshotBatch() {
       return modeler;
     }),
 
-    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/rules/img/message-reference/right.png', async (filepath) => {
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/message-reference/right.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/message-reference/right.bpmn') ],
             config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
 


### PR DESCRIPTION
Currently modeler screenshots end up in the wrong location:

https://github.com/camunda/camunda-docs/tree/main/docs/components/modeler/reference/rules/img

The right location is:

https://github.com/camunda/camunda-docs/tree/main/docs/components/modeler/reference/modeling-guidance/rules/img

----

Cf. https://github.com/camunda/camunda-docs/pull/3385