### PR TITLE
feat: generate history-time-to-live screenshot

### DIFF
--- a/lib/fixtures/bpmn/modeling-guidance/history-time-to-live/info.bpmn
+++ b/lib/fixtures/bpmn/modeling-guidance/history-time-to-live/info.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_01qggld" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.21.0-dev" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.20.0">
+  <bpmn:process id="Process_0bn5inh" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0leghhu</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_06xx9of">
+      <bpmn:incoming>Flow_0leghhu</bpmn:incoming>
+      <bpmn:outgoing>Flow_0q19wr6</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0leghhu" sourceRef="StartEvent_1" targetRef="Activity_06xx9of" />
+    <bpmn:endEvent id="Event_136jovx">
+      <bpmn:incoming>Flow_0q19wr6</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0q19wr6" sourceRef="Activity_06xx9of" targetRef="Event_136jovx" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0bn5inh">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_06xx9of_di" bpmnElement="Activity_06xx9of">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_136jovx_di" bpmnElement="Event_136jovx">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0leghhu_di" bpmnElement="Flow_0leghhu">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0q19wr6_di" bpmnElement="Flow_0q19wr6">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/lib/modelingGuidance.js
+++ b/lib/modelingGuidance.js
@@ -241,8 +241,22 @@ module.exports = function startScreenshotBatch() {
       await modeler.takeScreenshot(filepath);
 
       return modeler;
-    })
+    }),
 
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/history-time-to-live/info.png', async (filepath) => {
+      const diagramPaths = [ path.join(__dirname, './fixtures/bpmn/modeling-guidance/history-time-to-live/info.bpmn') ],
+            config = path.join(__dirname, './fixtures/user-data/small_with_prop_panel.json');
+
+      const modeler = await createModeler({ diagramPaths, configPath: config });
+
+      await modeler.click('[title="Toggle problems view"]');
+
+      await modeler.click('.linting-tab-item');
+
+      await modeler.takeScreenshot(filepath);
+
+      return modeler;
+    })
   ];
 
 };


### PR DESCRIPTION
Generate screenshot for HTTL.

Related to https://github.com/camunda/camunda-modeler/issues/4062