### PR TITLE
fix(cloud): do not add additional `https:`

### DIFF
--- a/lib/cloudReference.js
+++ b/lib/cloudReference.js
@@ -13,7 +13,7 @@ const annotationOptions = {
 const CLIENT_ID = process.env.CLIENT_ID || 'p8isUasaaaaaaaaa.uiQOel760fTh2';
 const CLIENT_SECRET = process.env.CLIENT_SECRET || '**********************';
 
-const SAAS_CLUSTER_URL = process.env.CLUSTER_URL || '1fajsag1sga.jfk-1.zeebe.camunda.io';
+const SAAS_CLUSTER_URL = process.env.CLUSTER_URL || 'https://1fajsag1sga.jfk-1.zeebe.camunda.io';
 const SAAS_OAUTH_URL = process.env.OAUTH_URL || 'https://login.cloud.camunda.io/oauth/token';
 const SAAS_OAUTH_AUDIENCE = process.env.OAUTH_AUDIENCE || 'zeebe.camunda.io';
 
@@ -411,7 +411,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
         await modeler.click('button[title="Deploy current diagram"]');
         await modeler.click('label[for="radio-element-camunda-8-self-managed"]');
         await modeler.click('label[for="radio-element-oauth"]');
-        await modeler.setValue('input[name="endpoint.contactPoint"]', `https://${SAAS_CLUSTER_URL}`);
+        await modeler.setValue('input[name="endpoint.contactPoint"]', SAAS_CLUSTER_URL);
         await modeler.setValue('input[name="endpoint.clientId"]', CLIENT_ID);
         await modeler.setValue('input[name="endpoint.clientSecret"]', CLIENT_SECRET);
         await modeler.setValue('input[name="endpoint.oauthURL"]', SAAS_OAUTH_URL);


### PR DESCRIPTION
The `CLUSTER_URL` we provide in the environment already has the correct `https` header. This corrects the Screenshot.

All other places we use the `SAAS_CLUSTER_URL` already use it correctly.

Current `camunda-docs/docs/self-managed/modeler/desktop-modeler/img/deploy-success.png`: 
![deploy-success](https://github.com/camunda/camunda-docs-modeler-screenshots/assets/21984219/e179b6dc-24cc-498d-ba1c-b0dca337513c)


Proposed change:
![deploy-success](https://github.com/camunda/camunda-docs-modeler-screenshots/assets/21984219/920678c0-67d5-4748-948c-5c8916ae13f4)
