### PR TITLE
fix: encode quotation marks in feel/right example

### DIFF
--- a/lib/fixtures/bpmn/modeling-guidance/feel/right.bpmn
+++ b/lib/fixtures/bpmn/modeling-guidance/feel/right.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0otvly3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.13.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0otvly3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.33.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
   <bpmn:process id="Process_1po7pwz" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1xq6ms4</bpmn:outgoing>
@@ -7,7 +7,7 @@
     <bpmn:sequenceFlow id="Flow_1xq6ms4" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
     <bpmn:serviceTask id="ServiceTask_1">
       <bpmn:extensionElements>
-        <zeebe:taskDefinition type="=\"type\"" />
+        <zeebe:taskDefinition type="=&#34;type&#34;" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1xq6ms4</bpmn:incoming>
       <bpmn:outgoing>Flow_0sku99n</bpmn:outgoing>


### PR DESCRIPTION
Not sure why the encoding was broken in the first place, but it's now fixed.

![right](https://github.com/user-attachments/assets/4aeafa2e-44e3-4d5e-8902-899b045f054d)

Closes #98