### PR TITLE
fix: application process resource linking

### DIFF
--- a/lib/camunda-docs/cloudReference.js
+++ b/lib/camunda-docs/cloudReference.js
@@ -482,7 +482,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
         element.type('calc');
 
-        await modeler.pause(500);
+        await modeler.pause(5000);
 
         await modeler.takeScreenshot(filepath);
         return modeler;


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-docs/pull/5740/files#diff-df1f4460709863d0664c545bb4b8a6b08bf389872dae3116f04b6798ba7bbaeb

It seems the search updates not fast enough, sometimes only `ca` or `cal` are entered in the input field or the search is not filtered yet. 

Broken example: 
![image](https://github.com/user-attachments/assets/9e95094a-35e8-4396-a88c-d97e91387f86)

With sleep: search works as expected but properties panel is not showing the business rule

![link-resources](https://github.com/user-attachments/assets/6ef9ae20-a50b-4edf-8710-9775d7b90e7c)

> I'm aware of the only, I want to quickly check the CI. because locally the screen resolution does not work for me

