### PR TITLE
feat: update variables input selector to 5.37

### DIFF
--- a/lib/camunda-docs/cloudReference.js
+++ b/lib/camunda-docs/cloudReference.js
@@ -26,6 +26,8 @@ const SELF_MANAGED_OAUTH_AUDIENCE = process.env.SELF_MANAGED_OAUTH_AUDIENCE || '
 const DEPLOYMENT_BUTTON_SELECTOR = 'button[title="Open file deployment"]';
 const START_INSTANCE_BUTTON_SELECTOR = 'button[title="Open start instance"]';
 
+const VARIABLES_INPUT_SELECTOR = '.cm-content';
+
 module.exports = function startScreenshotBatch(displayVersion) {
 
   return [
@@ -255,7 +257,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
         await modeler.pause(2000);
 
-        await modeler.setValue('textarea[name="variables"]', '{ "myVariable": 1 }');
+        await modeler.setValue(VARIABLES_INPUT_SELECTOR, '{ "myVariable": 1 }');
 
         await modeler.pause(2000);
 
@@ -290,7 +292,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
         await modeler.pause(2000);
 
-        await modeler.setValue('textarea[name="variables"]', '{ "a": 1 }');
+        await modeler.setValue(VARIABLES_INPUT_SELECTOR, '{ "a": 1 }');
 
         await modeler.click('div.section__body button.btn-primary');
 


### PR DESCRIPTION
Alternative to https://github.com/camunda/camunda-docs-modeler-screenshots/pull/114. We need to update the selector to point at codemirror contenteditable element.