### PR TITLE
feat: add no-loop rule screenshots

### DIFF
--- a/lib/camunda-docs/modelingGuidance.js
+++ b/lib/camunda-docs/modelingGuidance.js
@@ -241,6 +241,34 @@ module.exports = function startScreenshotBatch() {
       await modeler.takeScreenshot(filepath);
 
       return modeler;
+    }),
+
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/no-loop/wrong.png', async (filepath) => {
+      const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/no-loop/wrong.bpmn') ],
+            config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
+
+      const modeler = await createModeler({ diagramPaths, configPath: config });
+
+      await modeler.click('[title="Toggle problems view"]');
+
+      await modeler.click('.linting-tab-item');
+
+      await modeler.takeScreenshot(filepath);
+
+      return modeler;
+    }),
+
+    () => triggerScreenshot('camunda-docs/docs/components/modeler/reference/modeling-guidance/rules/img/no-loop/right.png', async (filepath) => {
+      const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/no-loop/right.bpmn') ],
+            config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
+
+      const modeler = await createModeler({ diagramPaths, configPath: config });
+
+      await modeler.click('[title="Toggle problems view"]');
+
+      await modeler.takeScreenshot(filepath);
+
+      return modeler;
     })
   ];
 

--- a/lib/fixtures/bpmn/modeling-guidance/no-loop/right.bpmn
+++ b/lib/fixtures/bpmn/modeling-guidance/no-loop/right.bpmn
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ilt917" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="Event_0cbobvn">
+      <bpmn:outgoing>Flow_1bx7o7k</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_0mp6ej8" name="Process">
+      <bpmn:incoming>Flow_1bx7o7k</bpmn:incoming>
+      <bpmn:incoming>Flow_19r7txe</bpmn:incoming>
+      <bpmn:outgoing>Flow_0odtau6</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1bx7o7k" sourceRef="Event_0cbobvn" targetRef="Activity_0mp6ej8" />
+    <bpmn:endEvent id="Event_1sk6lp9">
+      <bpmn:incoming>Flow_16fgk5q</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0odtau6" sourceRef="Activity_0mp6ej8" targetRef="Gateway_096494p" />
+    <bpmn:exclusiveGateway id="Gateway_096494p">
+      <bpmn:incoming>Flow_0odtau6</bpmn:incoming>
+      <bpmn:outgoing>Flow_16fgk5q</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1uq5bj0</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_16fgk5q" sourceRef="Gateway_096494p" targetRef="Event_1sk6lp9">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1uq5bj0" sourceRef="Gateway_096494p" targetRef="Event_0for580">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_19r7txe" sourceRef="Event_0for580" targetRef="Activity_0mp6ej8" />
+    <bpmn:intermediateCatchEvent id="Event_0for580">
+      <bpmn:incoming>Flow_1uq5bj0</bpmn:incoming>
+      <bpmn:outgoing>Flow_19r7txe</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_14zizkg">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">=30</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_0cbobvn_di" bpmnElement="Event_0cbobvn">
+        <dc:Bounds x="152" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0mp6ej8_di" bpmnElement="Activity_0mp6ej8">
+        <dc:Bounds x="240" y="100" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1sk6lp9_di" bpmnElement="Event_1sk6lp9">
+        <dc:Bounds x="522" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_096494p_di" bpmnElement="Gateway_096494p" isMarkerVisible="true">
+        <dc:Bounds x="385" y="115" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0b60l5q_di" bpmnElement="Event_0for580">
+        <dc:Bounds x="332" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1bx7o7k_di" bpmnElement="Flow_1bx7o7k">
+        <di:waypoint x="188" y="140" />
+        <di:waypoint x="240" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0odtau6_di" bpmnElement="Flow_0odtau6">
+        <di:waypoint x="340" y="140" />
+        <di:waypoint x="385" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16fgk5q_di" bpmnElement="Flow_16fgk5q">
+        <di:waypoint x="435" y="140" />
+        <di:waypoint x="522" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1uq5bj0_di" bpmnElement="Flow_1uq5bj0">
+        <di:waypoint x="410" y="165" />
+        <di:waypoint x="410" y="250" />
+        <di:waypoint x="368" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19r7txe_di" bpmnElement="Flow_19r7txe">
+        <di:waypoint x="332" y="250" />
+        <di:waypoint x="290" y="250" />
+        <di:waypoint x="290" y="180" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/lib/fixtures/bpmn/modeling-guidance/no-loop/wrong.bpmn
+++ b/lib/fixtures/bpmn/modeling-guidance/no-loop/wrong.bpmn
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ilt917" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="Event_0cbobvn">
+      <bpmn:outgoing>Flow_1bx7o7k</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_0mp6ej8" name="Process">
+      <bpmn:incoming>Flow_1bx7o7k</bpmn:incoming>
+      <bpmn:incoming>Flow_1uq5bj0</bpmn:incoming>
+      <bpmn:outgoing>Flow_0odtau6</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1bx7o7k" sourceRef="Event_0cbobvn" targetRef="Activity_0mp6ej8" />
+    <bpmn:endEvent id="Event_1sk6lp9">
+      <bpmn:incoming>Flow_16fgk5q</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0odtau6" sourceRef="Activity_0mp6ej8" targetRef="Gateway_096494p" />
+    <bpmn:exclusiveGateway id="Gateway_096494p">
+      <bpmn:incoming>Flow_0odtau6</bpmn:incoming>
+      <bpmn:outgoing>Flow_16fgk5q</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1uq5bj0</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_16fgk5q" sourceRef="Gateway_096494p" targetRef="Event_1sk6lp9">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1uq5bj0" sourceRef="Gateway_096494p" targetRef="Activity_0mp6ej8">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_0cbobvn_di" bpmnElement="Event_0cbobvn">
+        <dc:Bounds x="152" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0mp6ej8_di" bpmnElement="Activity_0mp6ej8">
+        <dc:Bounds x="240" y="100" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1sk6lp9_di" bpmnElement="Event_1sk6lp9">
+        <dc:Bounds x="522" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_096494p_di" bpmnElement="Gateway_096494p" isMarkerVisible="true">
+        <dc:Bounds x="385" y="115" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1bx7o7k_di" bpmnElement="Flow_1bx7o7k">
+        <di:waypoint x="188" y="140" />
+        <di:waypoint x="240" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0odtau6_di" bpmnElement="Flow_0odtau6">
+        <di:waypoint x="340" y="140" />
+        <di:waypoint x="385" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16fgk5q_di" bpmnElement="Flow_16fgk5q">
+        <di:waypoint x="435" y="140" />
+        <di:waypoint x="522" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1uq5bj0_di" bpmnElement="Flow_1uq5bj0">
+        <di:waypoint x="410" y="165" />
+        <di:waypoint x="410" y="250" />
+        <di:waypoint x="290" y="250" />
+        <di:waypoint x="290" y="180" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Related to: https://github.com/camunda/camunda-modeler/issues/5122

Added modeling guidance no-loop section screenshots

<img width="2600" height="1344" alt="wrong" src="https://github.com/user-attachments/assets/17bdee6f-830e-4112-a594-93586051e080" />
<img width="2600" height="1344" alt="right" src="https://github.com/user-attachments/assets/fdc51228-913d-4362-a3f8-b5afc3cf94d6" />

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
