### PR TITLE
fix: make sure bold text in annotation is bold

### DIFF
--- a/lib/helper/annotations.js
+++ b/lib/helper/annotations.js
@@ -22,6 +22,15 @@ module.exports.addAnnotation = async function addAnnotation(selector, text, opti
 
   document.body.appendChild(textBox);
 
+  // find all <b> tags and make sure they are bold
+  // because some environments (like puppeteer with certain fonts)
+  // do not render <b> as bold by default
+  const bolds = textBox.querySelectorAll('b');
+
+  bolds.forEach((b) => {
+    b.style.fontWeight = 'bold';
+  });
+
   await new Promise(resolve => {setTimeout(resolve, 100);});
 
   // This calculates the positioning of the text box and the arrow


### PR DESCRIPTION
In recent workflow runs the [generated screenshots](https://github.com/camunda/camunda-docs/pull/6647/files) indicate that the `<b>` tags aren't rendered as bold by default anymore. 

<img width="1161" height="672" alt="image" src="https://github.com/user-attachments/assets/18afeab9-1450-4f09-a2eb-fcab24abb5c7" />

After the fix:

<img width="639" height="358" alt="image" src="https://github.com/user-attachments/assets/9be0db0c-40af-4a6a-bdf1-55ce56b1b92b" />
