### PR TITLE
fix: use no connection as default connection

### DIFF
--- a/lib/fixtures/user-data/bottom_panel.json
+++ b/lib/fixtures/user-data/bottom_panel.json
@@ -28,5 +28,6 @@
       "width": 1300,
       "height": 900
     }
-  }
+  },
+  "lastUsedConnection": "NO_CONNECTION"
 }

--- a/lib/fixtures/user-data/default_config.json
+++ b/lib/fixtures/user-data/default_config.json
@@ -23,5 +23,6 @@
       "width": 1300,
       "height": 900
     }
-  }
+  },
+  "lastUsedConnection": "NO_CONNECTION"
 }

--- a/lib/fixtures/user-data/extra_small_no_prop_panel.json
+++ b/lib/fixtures/user-data/extra_small_no_prop_panel.json
@@ -11,7 +11,7 @@
       "propertiesPanel": {
         "open": false,
         "width": 420
-        }
+      }
     }
   },
   "window": {
@@ -23,5 +23,6 @@
       "width": 1100,
       "height": 550
     }
-  }
+  },
+  "lastUsedConnection": "NO_CONNECTION"
 }

--- a/lib/fixtures/user-data/large_drd_overview.json
+++ b/lib/fixtures/user-data/large_drd_overview.json
@@ -12,7 +12,7 @@
       "propertiesPanel": {
         "open": false,
         "width": 420
-        }
+      }
     }
   },
   "window": {
@@ -24,5 +24,6 @@
       "width": 1200,
       "height": 700
     }
-  }
+  },
+  "lastUsedConnection": "NO_CONNECTION"
 }

--- a/lib/fixtures/user-data/large_with_prop_panel.json
+++ b/lib/fixtures/user-data/large_with_prop_panel.json
@@ -11,7 +11,7 @@
       "propertiesPanel": {
         "open": true,
         "width": 420
-        }
+      }
     }
   },
   "window": {
@@ -23,5 +23,6 @@
       "width": 1800,
       "height": 900
     }
-  }
+  },
+  "lastUsedConnection": "NO_CONNECTION"
 }

--- a/lib/fixtures/user-data/quickstart_large_with_prop_panel.json
+++ b/lib/fixtures/user-data/quickstart_large_with_prop_panel.json
@@ -23,5 +23,6 @@
       "width": 1200,
       "height": 900
     }
-  }
+  },
+  "lastUsedConnection": "NO_CONNECTION"
 }

--- a/lib/fixtures/user-data/quickstart_no_prop_panel.json
+++ b/lib/fixtures/user-data/quickstart_no_prop_panel.json
@@ -22,5 +22,6 @@
       "width": 1200,
       "height": 700
     }
-  }
+  },
+  "lastUsedConnection": "NO_CONNECTION"
 }

--- a/lib/fixtures/user-data/quickstart_with_prop_panel.json
+++ b/lib/fixtures/user-data/quickstart_with_prop_panel.json
@@ -28,5 +28,6 @@
       "width": 1200,
       "height": 700
     }
-  }
+  },
+  "lastUsedConnection": "NO_CONNECTION"
 }

--- a/lib/fixtures/user-data/quickstart_with_prop_panel_entries_visible.json
+++ b/lib/fixtures/user-data/quickstart_with_prop_panel_entries_visible.json
@@ -34,5 +34,6 @@
       "width": 1200,
       "height": 700
     }
-  }
+  },
+  "lastUsedConnection": "NO_CONNECTION"
 }

--- a/lib/fixtures/user-data/small_with_prop_panel.json
+++ b/lib/fixtures/user-data/small_with_prop_panel.json
@@ -11,7 +11,7 @@
       "propertiesPanel": {
         "open": true,
         "width": 420
-        }
+      }
     }
   },
   "window": {
@@ -23,5 +23,6 @@
       "width": 1300,
       "height": 700
     }
-  }
+  },
+  "lastUsedConnection": "NO_CONNECTION"
 }

--- a/lib/fixtures/user-data/wide_with_prop_panel.json
+++ b/lib/fixtures/user-data/wide_with_prop_panel.json
@@ -23,5 +23,6 @@
       "width": 1800,
       "height": 700
     }
-  }
+  },
+  "lastUsedConnection": "NO_CONNECTION"
 }


### PR DESCRIPTION
Use no connection as default connection. This prevents our screenshots to show a loading spinner. Reason i dont like the spinners: during screenshot update reviews i mostly look at file size changes. but due to the spinner its always different (not guaranteed to be in same position) -> harder to see actual changes

Requires nightly or 5.46 to take effect

eg old/current from https://docs.camunda.io/docs/components/modeler/desktop-modeler/:
<img width="1200" height="673" alt="image" src="https://github.com/user-attachments/assets/d455a05c-04b5-4e20-87b1-e2fa6ba880cc" />

now: 
<img width="2400" height="1336" alt="image" src="https://github.com/user-attachments/assets/4402bce0-9950-4f05-94f6-b101166ceed0" />

Alternatives considered:
- leave the loading states (but we would still ping something during load)
- wait for connection success -> would drasticly increase runtime and engine load

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
