### PR TITLE
Sidepanel adjustments

### DIFF
--- a/lib/camunda-docs-manual/userGuide.js
+++ b/lib/camunda-docs-manual/userGuide.js
@@ -45,8 +45,8 @@ module.exports = function startScreenshotBatch(displayVersion) {
       await modeler.click('text="myProcessVariableName"');
 
       await modeler.takeScreenshot(filepath, {
-        left: 1379,
-        top: 285,
+        left: 1380,
+        top: 288,
         width: 420,
         height: 512
       });

--- a/lib/camunda-docs-static/quickstart.js
+++ b/lib/camunda-docs-static/quickstart.js
@@ -235,8 +235,8 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
         await modeler.takeScreenshot(filepath,
           {
-            left: 1379,
-            top: 156,
+            left: 1380,
+            top: 160,
             width: 420,
             height: 452
           });
@@ -354,8 +354,8 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
         await modeler.takeScreenshot(filepath,
           {
-            left: 1379,
-            top: 86,
+            left: 1380,
+            top: 96,
             width: 420,
             height: 450
           });
@@ -444,8 +444,8 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
         await modeler.takeScreenshot(filepath,
           {
-            left: 1379,
-            top: 156,
+            left: 1380,
+            top: 161,
             width: 420,
             height: 512
           });
@@ -453,6 +453,8 @@ module.exports = function startScreenshotBatch(displayVersion) {
       }
     ),
 
+    // TODO: waiting for https://github.com/camunda/camunda-modeler/issues/5751
+    { skip:
     () => triggerScreenshot('camunda-docs-static/get-started/content/quick-start/img/modeler-new-dmn-diagram-properties.png',
       async (filepath) => {
         const diagramPaths = [ path.join(__dirname, '../fixtures/dmn/quickstart/step4.2.dmn') ],
@@ -466,6 +468,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
         return modeler;
       }
     ),
+    },
 
     // TODO: waiting for https://github.com/bpmn-io/dmn-js-properties-panel/issues/29
     /* () => triggerScreenshot('camunda-docs-static/get-started/content/quick-start/img/modeler-new-dmn-diagram.png',
@@ -499,7 +502,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
         await modeler.takeScreenshot(filepath, {
           left: 140,
-          top: 115,
+          top: 120,
           width: 100,
           height: 100
         });

--- a/lib/camunda-docs/cloudReference.js
+++ b/lib/camunda-docs/cloudReference.js
@@ -513,7 +513,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
         const modeler = await createModeler({ diagramPaths, processApplicationPaths, configPath: config, displayVersion });
 
         await modeler.click('.djs-element[data-element-id="Activity_1t3a333"]');
-        await modeler.waitForExist('.bio-properties-panel-header-type >> "Business Rule Task"');
+        await modeler.waitForExist('.side-panel-header__type >> "Business Rule Task"');
 
         await modeler.click('.djs-context-pad .entry[data-action="replace"]');
 
@@ -521,7 +521,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
         await element.focus();
         await element.pressSequentially('calc', { delay: 100 });
-        await modeler.waitForExist('.djs-popup-results [data-group="decisions"]:first-of-type');
+        await modeler.waitForExist('.djs-popup-results');
 
         await modeler.takeScreenshot(filepath,
           {

--- a/lib/camunda-docs/cloudReference.js
+++ b/lib/camunda-docs/cloudReference.js
@@ -49,7 +49,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
       'camunda-docs/docs/components/modeler/desktop-modeler/img/new-diagram.png',
       async (filepath) => {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram1.bpmn') ],
-              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop+var_panel.json');
 
         const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 

--- a/lib/camunda-docs/modelingGuidance.js
+++ b/lib/camunda-docs/modelingGuidance.js
@@ -102,6 +102,8 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
       await modeler.click('.linting-tab-item');
 
+      await modeler.scrollIntoViewIfNeeded('.bio-properties-panel-error');
+
       await modeler.takeScreenshot(filepath);
 
       return modeler;
@@ -152,6 +154,8 @@ module.exports = function startScreenshotBatch(displayVersion) {
       await modeler.click('[title="Toggle problems view"]');
 
       await modeler.click('.linting-tab-item');
+
+      await modeler.scrollIntoViewIfNeeded('.bio-properties-panel-error');
 
       await modeler.takeScreenshot(filepath);
 

--- a/lib/fixtures/bpmn/quickstart/step1.3.bpmn
+++ b/lib/fixtures/bpmn/quickstart/step1.3.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_03qvj40" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_03qvj40" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.46.0">
   <bpmn:process id="payment-retrival" name="Payment Retrival" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Payment Retrival Requested">
       <bpmn:outgoing>Flow_168spo2</bpmn:outgoing>

--- a/lib/fixtures/user-data/bottom_panel.json
+++ b/lib/fixtures/user-data/bottom_panel.json
@@ -19,6 +19,9 @@
       }
     }
   },
+  "hints": {
+    "panelToggleDismissed": true
+  },
   "window": {
     "fullScreen": false,
     "maximize": false,

--- a/lib/fixtures/user-data/bottom_panel.json
+++ b/lib/fixtures/user-data/bottom_panel.json
@@ -8,9 +8,11 @@
       "log": {
         "open": false
       },
-      "propertiesPanel": {
-        "open": false,
-        "width": 420
+      "sidePanel": {
+        "open": false
+      },
+      "variablesSidePanel": {
+        "open": false
       },
       "panel": {
         "open": true,

--- a/lib/fixtures/user-data/default_config.json
+++ b/lib/fixtures/user-data/default_config.json
@@ -8,9 +8,11 @@
       "log": {
         "open": false
       },
-      "propertiesPanel": {
-        "open": false,
-        "width": 420
+      "sidePanel": {
+        "open": false
+      },
+      "variablesSidePanel": {
+        "open": false
       }
     }
   },

--- a/lib/fixtures/user-data/default_config.json
+++ b/lib/fixtures/user-data/default_config.json
@@ -14,6 +14,9 @@
       }
     }
   },
+  "hints": {
+    "panelToggleDismissed": true
+  },
   "window": {
     "fullScreen": false,
     "maximize": false,

--- a/lib/fixtures/user-data/extra_small_no_prop_panel.json
+++ b/lib/fixtures/user-data/extra_small_no_prop_panel.json
@@ -8,9 +8,11 @@
       "log": {
         "open": false
       },
-      "propertiesPanel": {
-        "open": false,
-        "width": 420
+      "sidePanel": {
+        "open": false
+      },
+      "variablesSidePanel": {
+        "open": false
       }
     }
   },

--- a/lib/fixtures/user-data/extra_small_no_prop_panel.json
+++ b/lib/fixtures/user-data/extra_small_no_prop_panel.json
@@ -14,6 +14,9 @@
       }
     }
   },
+  "hints": {
+    "panelToggleDismissed": true
+  },
   "window": {
     "fullScreen": false,
     "maximize": false,

--- a/lib/fixtures/user-data/large_drd_overview.json
+++ b/lib/fixtures/user-data/large_drd_overview.json
@@ -15,6 +15,9 @@
       }
     }
   },
+  "hints": {
+    "panelToggleDismissed": true
+  },
   "window": {
     "fullScreen": false,
     "maximize": false,

--- a/lib/fixtures/user-data/large_drd_overview.json
+++ b/lib/fixtures/user-data/large_drd_overview.json
@@ -9,9 +9,11 @@
       "log": {
         "open": false
       },
-      "propertiesPanel": {
-        "open": false,
-        "width": 420
+      "sidePanel": {
+        "open": false
+      },
+      "variablesSidePanel": {
+        "open": false
       }
     }
   },

--- a/lib/fixtures/user-data/large_with_prop_panel.json
+++ b/lib/fixtures/user-data/large_with_prop_panel.json
@@ -8,9 +8,13 @@
       "log": {
         "open": false
       },
-      "propertiesPanel": {
+      "sidePanel": {
         "open": true,
-        "width": 420
+        "width": 420,
+        "tab": "properties"
+      },
+      "variablesSidePanel": {
+        "open": false
       }
     }
   },

--- a/lib/fixtures/user-data/large_with_prop_panel.json
+++ b/lib/fixtures/user-data/large_with_prop_panel.json
@@ -14,6 +14,9 @@
       }
     }
   },
+  "hints": {
+    "panelToggleDismissed": true
+  },
   "window": {
     "fullScreen": false,
     "maximize": false,

--- a/lib/fixtures/user-data/quickstart_large_with_prop_panel.json
+++ b/lib/fixtures/user-data/quickstart_large_with_prop_panel.json
@@ -8,9 +8,13 @@
       "log": {
         "open": false
       },
-      "propertiesPanel": {
+      "sidePanel": {
         "open": true,
-        "width": 420
+        "width": 420,
+        "tab": "properties"
+      },
+      "variablesSidePanel": {
+        "open": false
       }
     }
   },

--- a/lib/fixtures/user-data/quickstart_large_with_prop_panel.json
+++ b/lib/fixtures/user-data/quickstart_large_with_prop_panel.json
@@ -14,6 +14,9 @@
       }
     }
   },
+  "hints": {
+    "panelToggleDismissed": true
+  },
   "window": {
     "fullScreen": false,
     "maximize": false,

--- a/lib/fixtures/user-data/quickstart_no_prop_panel.json
+++ b/lib/fixtures/user-data/quickstart_no_prop_panel.json
@@ -13,6 +13,9 @@
       }
     }
   },
+  "hints": {
+    "panelToggleDismissed": true
+  },
   "window": {
     "fullScreen": false,
     "maximize": false,

--- a/lib/fixtures/user-data/quickstart_no_prop_panel.json
+++ b/lib/fixtures/user-data/quickstart_no_prop_panel.json
@@ -8,7 +8,10 @@
       "log": {
         "open": false
       },
-      "propertiesPanel": {
+      "sidePanel": {
+        "open": false
+      },
+      "variablesSidePanel": {
         "open": false
       }
     }

--- a/lib/fixtures/user-data/quickstart_with_prop+var_panel.json
+++ b/lib/fixtures/user-data/quickstart_with_prop+var_panel.json
@@ -21,7 +21,7 @@
         }
       },
       "variablesSidePanel": {
-        "open": false
+        "open": true
       }
     }
   },

--- a/lib/fixtures/user-data/quickstart_with_prop_panel.json
+++ b/lib/fixtures/user-data/quickstart_with_prop_panel.json
@@ -19,6 +19,9 @@
       }
     }
   },
+  "hints": {
+    "panelToggleDismissed": true
+  },
   "window": {
     "fullScreen": false,
     "maximize": false,

--- a/lib/fixtures/user-data/quickstart_with_prop_panel_entries_visible.json
+++ b/lib/fixtures/user-data/quickstart_with_prop_panel_entries_visible.json
@@ -8,9 +8,12 @@
       "log": {
         "open": false
       },
-      "propertiesPanel": {
+      "sidePanel": {
         "open": true,
         "width": 420,
+        "tab": "properties"
+      },
+      "propertiesPanel": {
         "groups": {
           "ElementTemplates__CustomProperties": {
             "open": false
@@ -22,6 +25,9 @@
             "open": true
           }
         }
+      },
+      "variablesSidePanel": {
+        "open": false
       }
     }
   },

--- a/lib/fixtures/user-data/quickstart_with_prop_panel_entries_visible.json
+++ b/lib/fixtures/user-data/quickstart_with_prop_panel_entries_visible.json
@@ -25,6 +25,9 @@
       }
     }
   },
+  "hints": {
+    "panelToggleDismissed": true
+  },
   "window": {
     "fullScreen": false,
     "maximize": false,

--- a/lib/fixtures/user-data/small_with_prop_panel.json
+++ b/lib/fixtures/user-data/small_with_prop_panel.json
@@ -8,9 +8,13 @@
       "log": {
         "open": false
       },
-      "propertiesPanel": {
+      "sidePanel": {
         "open": true,
-        "width": 420
+        "width": 420,
+        "tab": "properties"
+      },
+      "variablesSidePanel": {
+        "open": false
       }
     }
   },

--- a/lib/fixtures/user-data/small_with_prop_panel.json
+++ b/lib/fixtures/user-data/small_with_prop_panel.json
@@ -14,6 +14,9 @@
       }
     }
   },
+  "hints": {
+    "panelToggleDismissed": true
+  },
   "window": {
     "fullScreen": false,
     "maximize": false,

--- a/lib/fixtures/user-data/wide_with_prop_panel.json
+++ b/lib/fixtures/user-data/wide_with_prop_panel.json
@@ -14,6 +14,9 @@
       }
     }
   },
+  "hints": {
+    "panelToggleDismissed": true
+  },
   "window": {
     "fullScreen": false,
     "maximize": false,

--- a/lib/fixtures/user-data/wide_with_prop_panel.json
+++ b/lib/fixtures/user-data/wide_with_prop_panel.json
@@ -8,9 +8,13 @@
       "log": {
         "open": false
       },
-      "propertiesPanel": {
+      "sidePanel": {
         "open": true,
-        "width": 320
+        "width": 320,
+        "tab": "properties"
+      },
+      "variablesSidePanel": {
+        "open": false
       }
     }
   },


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-docs-modeler-screenshots/issues/148

- removes the side panel hint by default 
  ```
   "hints": {
      "panelToggleDismissed": true
    }
  ```

  removes this one: 
  <img width="251" height="134" alt="image" src="https://github.com/user-attachments/assets/4704854f-1613-436b-a473-780bd7fd3d07" />

- close variable sidepanel by default (cf https://github.com/camunda/camunda-docs/pull/8561/changes/de9374a9012a372e9dec7059e692e8c8392ae008 for effect)

- migrate legacy propertiesPanel to sidePanel config

- decided to show variable panel on components/modeler/desktop-modeler/img/new-diagram.png (we could adjust others to do the same with `quickstart_with_prop+var_panel.json`, but most of the time it was just to cluttered with the variables panel)
 
  <img width="1320" height="448" alt="image" src="https://github.com/user-attachments/assets/683dcbd2-071d-463d-b7e7-fc4b9b728dd0" />

- fixes one failing task due to changed classes
- skips currently failing task
- adjusts window size and rects to accomodate increased top bar size but still keep the same resolution and area 


<!--


Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
