### PR TITLE
Connection Manager Adjustments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+CLIENT_ID=p8isUasaaaaaaaaa.uiQOel760fTh2
+CLIENT_SECRET=**********************
+
+CLUSTER_URL=https://1fajsag1sga.jfk-1.zeebe.camunda.io
+OAUTH_URL=https://login.cloud.camunda.io/oauth/token
+OAUTH_AUDIENCE=zeebe.camunda.io
+
+SELF_MANAGED_CLUSTER_URL=https://zeebe.example.com
+SELF_MANAGED_BASIC_AUTH_USERNAME=demo
+SELF_MANAGED_BASIC_AUTH_PASSWORD=demo
+SELF_MANAGED_OAUTH_URL=https://keycloak.example.com/auth/realms/camunda-platform/protocol/openid-connect/token
+SELF_MANAGED_OAUTH_AUDIENCE=zeebe-api

--- a/lib/camunda-docs/cloudReference.js
+++ b/lib/camunda-docs/cloudReference.js
@@ -14,8 +14,6 @@ const CLIENT_ID = process.env.CLIENT_ID || 'p8isUasaaaaaaaaa.uiQOel760fTh2';
 const CLIENT_SECRET = process.env.CLIENT_SECRET || '**********************';
 
 const SAAS_CLUSTER_URL = process.env.CLUSTER_URL || 'https://1fajsag1sga.jfk-1.zeebe.camunda.io';
-const SAAS_OAUTH_URL = process.env.OAUTH_URL || 'https://login.cloud.camunda.io/oauth/token';
-const SAAS_OAUTH_AUDIENCE = process.env.OAUTH_AUDIENCE || 'zeebe.camunda.io';
 
 const SELF_MANAGED_CLUSTER_URL = process.env.SELF_MANAGED_CLUSTER_URL || 'https://zeebe.example.com';
 const SELF_MANAGED_BASIC_AUTH_USERNAME = process.env.SELF_MANAGED_BASIC_AUTH_USERNAME || 'demo';
@@ -23,6 +21,8 @@ const SELF_MANAGED_BASIC_AUTH_PASSWORD = process.env.SELF_MANAGED_BASIC_AUTH_PAS
 const SELF_MANAGED_OAUTH_URL = process.env.SELF_MANAGED_OAUTH_URL || 'https://keycloak.example.com/auth/realms/camunda-platform/protocol/openid-connect/token';
 const SELF_MANAGED_OAUTH_AUDIENCE = process.env.SELF_MANAGED_OAUTH_AUDIENCE || 'zeebe-api';
 
+const CONNECTION_SELECTOR_BUTTON_SELECTOR = 'button[title="Configure Camunda 8 connection"]';
+const CONNECTION_MANAGER_BUTTON_SELECTOR = 'a:text("Manage connections")';
 const DEPLOYMENT_BUTTON_SELECTOR = 'button[title="Open file deployment"]';
 const START_INSTANCE_BUTTON_SELECTOR = 'button[title="Open start instance"]';
 const TASK_TESTING_BUTTON_SELECTOR = 'button[title="Toggle test view"]';
@@ -106,100 +106,279 @@ module.exports = function startScreenshotBatch(displayVersion) {
     ),
 
     () => triggerScreenshot(
-      'camunda-docs/docs/components/modeler/desktop-modeler/img/deploy-icon.png',
+      'camunda-docs/docs/components/modeler/desktop-modeler/img/connection-selector-offline.png',
       async (filepath) => {
-        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram2.bpmn') ],
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
         const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
-        await modeler.mouseOver(DEPLOYMENT_BUTTON_SELECTOR);
+        await modeler.mouseOver(CONNECTION_SELECTOR_BUTTON_SELECTOR);
 
         await modeler.takeScreenshot(filepath,
           {
             left: 0,
             bottom: 0,
-            width: 450,
-            height: 150
+            width: 400,
+            height: 200
           });
         return modeler;
       }
     ),
 
-    {
-      skip: () => triggerScreenshot(
-        'camunda-docs/docs/components/modeler/desktop-modeler/img/deploy-diagram-camunda-cloud.png',
-        async (filepath) => {
-          const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram2.bpmn') ],
-                config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+    () => triggerScreenshot(
+      'camunda-docs/docs/components/modeler/desktop-modeler/img/connection-selector-offline-open.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-          const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
-          await modeler.click(DEPLOYMENT_BUTTON_SELECTOR);
-          await modeler.click('label[for="radio-element-endpoint.targetType-camunda-8-saas"]');
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
 
-          await modeler.takeScreenshot(filepath);
-          return modeler;
-        }
-      )
-    },
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
 
-    {
-      skip: () => triggerScreenshot(
-        'camunda-docs/docs/components/modeler/desktop-modeler/img/deploy-diagram-camunda-cloud-success.png',
-        async (filepath) => {
-          const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram3.bpmn') ],
-                config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+    () => triggerScreenshot(
+      'camunda-docs/docs/components/modeler/desktop-modeler/img/connection-manager-add.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-          const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
-          await modeler.click(DEPLOYMENT_BUTTON_SELECTOR);
-          await modeler.click('label[for="radio-element-endpoint.targetType-camunda-8-saas"]');
-          await modeler.setValue('input[name="endpoint.camundaCloudClusterUrl"]', SAAS_CLUSTER_URL);
-          await modeler.setValue('input[name="endpoint.camundaCloudClientId"]', CLIENT_ID);
-          await modeler.setValue('input[name="endpoint.camundaCloudClientSecret"]', CLIENT_SECRET);
-          await modeler.pause(5000);
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+        await modeler.click(CONNECTION_MANAGER_BUTTON_SELECTOR);
+        await modeler.scrollIntoViewIfNeeded('button:text("Add connection")');
 
-          await modeler.click('.section__body button[type="submit"]');
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
 
-          await modeler.pause(4000);
+    () => triggerScreenshot(
+      'camunda-docs/docs/components/modeler/desktop-modeler/img/connection-manager-new-connection-loading.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-          await modeler.takeScreenshot(filepath);
-          return modeler;
-        }
-      )
-    },
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
-    {
-      skip: () => triggerScreenshot(
-        'camunda-docs/docs/components/modeler/desktop-modeler/img/deploy-diagram-camunda-cloud-remember.png',
-        async (filepath) => {
-          const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram3.bpmn') ],
-                config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+        await modeler.click(CONNECTION_MANAGER_BUTTON_SELECTOR);
 
-          const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+        await modeler.click('button:text("Add connection")');
 
-          await modeler.click(DEPLOYMENT_BUTTON_SELECTOR);
-          await modeler.click('label[for="radio-element-endpoint.targetType-camunda-8-saas"]');
-          await modeler.setValue('input[name="endpoint.camundaCloudClusterUrl"]', SAAS_CLUSTER_URL);
-          await modeler.setValue('input[name="endpoint.camundaCloudClientId"]', CLIENT_ID);
-          await modeler.setValue('input[name="endpoint.camundaCloudClientSecret"]', CLIENT_SECRET);
-          await modeler.click('div[role="dialog"] span.toggle-switch__slider');
-          await modeler.pause(1000);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].camundaCloudClusterUrl"]', SAAS_CLUSTER_URL);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].camundaCloudClientId"]', CLIENT_ID);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].camundaCloudClientSecret"]', CLIENT_SECRET);
 
-          await modeler.takeScreenshot(filepath);
-          return modeler;
-        }
-      )
-    },
+        await modeler.scrollIntoViewIfNeeded('input[name="connectionManagerPlugin.c8connections[2].camundaCloudClientSecret"]');
+
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
+
+    ()=> triggerScreenshot(
+      'camunda-docs/docs/components/modeler/desktop-modeler/img/connection-manager-new-connection-error.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+        await modeler.click(CONNECTION_MANAGER_BUTTON_SELECTOR);
+
+        await modeler.click('button:text("Add connection")');
+
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].camundaCloudClusterUrl"]', SAAS_CLUSTER_URL + 'invalid');
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].camundaCloudClientId"]', CLIENT_ID);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].camundaCloudClientSecret"]', CLIENT_SECRET);
+
+        await modeler.click('label[for="radio-element-connectionManagerPlugin.c8connections[2].targetType-camunda-8-saas"]');
+
+        await modeler.getElement('.status-icon.error');
+
+        await modeler.scrollIntoViewIfNeeded('input[name="connectionManagerPlugin.c8connections[2].camundaCloudClientSecret"]');
+
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
+
+    () => triggerScreenshot(
+      'camunda-docs/docs/components/modeler/desktop-modeler/img/connection-manager-new-connection-success.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+        await modeler.click(CONNECTION_MANAGER_BUTTON_SELECTOR);
+        await modeler.click('button:text("Add connection")');
+
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].camundaCloudClusterUrl"]', SAAS_CLUSTER_URL);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].camundaCloudClientId"]', CLIENT_ID);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].camundaCloudClientSecret"]', CLIENT_SECRET);
+
+        await modeler.click('label[for="radio-element-connectionManagerPlugin.c8connections[2].targetType-camunda-8-saas"]');
+
+        await modeler.getElement('span:text("Connected")');
+
+        await modeler.scrollIntoViewIfNeeded('input[name="connectionManagerPlugin.c8connections[2].camundaCloudClientSecret"]');
+
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
+
+    () => triggerScreenshot(
+      'camunda-docs/docs/components/modeler/desktop-modeler/img/connection-selector-dev-connection.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json'),
+              settingsPath = path.join(__dirname, '../fixtures/user-data/settings/default_connections.json'),
+              additionalConfig = {
+                files:{
+                  [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn')]:{
+                    'connection-manager':{
+                      connectionId: 'saas-1'
+                    }
+                  }
+                }
+              };
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, additionalConfig, displayVersion, settingsPath });
+
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+
+        await modeler.getElement('.status-icon.success');
+
+        await modeler.takeScreenshot(filepath,
+          {
+            left: 0,
+            bottom: 0,
+            width: 500,
+            height: 250
+          });
+        return modeler;
+      }
+    ),
+
+    () => triggerScreenshot(
+      'camunda-docs/docs/components/modeler/desktop-modeler/img/deploy-icon.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json'),
+              settingsPath = path.join(__dirname, '../fixtures/user-data/settings/default_connections.json'),
+              additionalConfig = {
+                files:{
+                  [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn')]:{
+                    'connection-manager':{
+                      connectionId: 'saas-1'
+                    }
+                  }
+                }
+              };
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, additionalConfig, displayVersion, settingsPath });
+
+        await modeler.mouseOver(DEPLOYMENT_BUTTON_SELECTOR);
+
+        await modeler.getElement('.status-icon.success');
+
+        await modeler.takeScreenshot(filepath,
+          {
+            left: 0,
+            bottom: 0,
+            width: 500,
+            height: 250
+          });
+        return modeler;
+      }
+    ),
+
+    () => triggerScreenshot(
+      'camunda-docs/docs/components/modeler/desktop-modeler/img/deploy-diagram.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json'),
+              settingsPath = path.join(__dirname, '../fixtures/user-data/settings/default_connections.json'),
+              additionalConfig = {
+                files:{
+                  [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn')]:{
+                    'connection-manager':{
+                      connectionId: 'saas-1'
+                    }
+                  }
+                }
+              };
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, additionalConfig, displayVersion, settingsPath });
+
+        await modeler.getElement('.status-icon.success');
+
+        await modeler.click(DEPLOYMENT_BUTTON_SELECTOR);
+
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
+
+    () => triggerScreenshot(
+      'camunda-docs/docs/components/modeler/desktop-modeler/img/deploy-diagram-success.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json'),
+              settingsPath = path.join(__dirname, '../fixtures/user-data/settings/default_connections.json'),
+              additionalConfig = {
+                files:{
+                  [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn')]:{
+                    'connection-manager':{
+                      connectionId: 'saas-1'
+                    }
+                  }
+                }
+              };
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, additionalConfig, displayVersion, settingsPath });
+
+        await modeler.getElement('.status-icon.success');
+
+        await modeler.click(DEPLOYMENT_BUTTON_SELECTOR);
+
+        await modeler.click('.section__body button[type="submit"]');
+
+        await modeler.getElement('h3:text("Process definition deployed")');
+
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
 
     () => triggerScreenshot(
       'camunda-docs/docs/components/modeler/desktop-modeler/img/start-instance-icon.png',
       async (filepath) => {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram3.bpmn') ],
-              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json'),
+              settingsPath = path.join(__dirname, '../fixtures/user-data/settings/default_connections.json'),
+              additionalConfig = {
+                files:{
+                  [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram3.bpmn')]:{
+                    'connection-manager':{
+                      connectionId: 'saas-1'
+                    }
+                  }
+                }
+              };
+        const modeler = await createModeler({ diagramPaths, configPath: config, additionalConfig, displayVersion, settingsPath });
 
-        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+        await modeler.getElement('.status-icon.success');
 
         await modeler.mouseOver(START_INSTANCE_BUTTON_SELECTOR);
 
@@ -207,253 +386,71 @@ module.exports = function startScreenshotBatch(displayVersion) {
           {
             left: 0,
             bottom: 0,
-            width: 450,
+            width: 500,
             height: 150
           });
         return modeler;
       }
     ),
 
-    {
-      skip: () => triggerScreenshot(
-        'camunda-docs/docs/components/modeler/desktop-modeler/img/start-instance-step-1.png',
-        async (filepath) => {
-          const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram3.bpmn') ],
-                config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
-
-          const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
-
-          await modeler.click(START_INSTANCE_BUTTON_SELECTOR);
-
-          await modeler.click('label[for="radio-element-endpoint.targetType-camunda-8-saas"]');
-
-          await modeler.setValue('input[name="endpoint.camundaCloudClusterUrl"]', SAAS_CLUSTER_URL);
-          await modeler.setValue('input[name="endpoint.camundaCloudClientId"]', CLIENT_ID);
-          await modeler.setValue('input[name="endpoint.camundaCloudClientSecret"]', CLIENT_SECRET);
-
-          await modeler.click('div[role="dialog"] span.toggle-switch__slider');
-
-          await modeler.pause(2000);
-
-          await modeler.takeScreenshot(filepath);
-
-          return modeler;
-        }
-      )
-    },
-
-    {
-      skip: () => triggerScreenshot(
-        'camunda-docs/docs/components/modeler/desktop-modeler/img/start-instance-step-2.png',
-        async (filepath) => {
-          const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram3.bpmn') ],
-                config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
-
-          const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
-
-          await modeler.click(START_INSTANCE_BUTTON_SELECTOR);
-
-          await modeler.click('label[for="radio-element-endpoint.targetType-camunda-8-saas"]');
-
-          await modeler.setValue('input[name="endpoint.camundaCloudClusterUrl"]', SAAS_CLUSTER_URL);
-          await modeler.setValue('input[name="endpoint.camundaCloudClientId"]', CLIENT_ID);
-          await modeler.setValue('input[name="endpoint.camundaCloudClientSecret"]', CLIENT_SECRET);
-
-          await modeler.click('div[role="dialog"] span.toggle-switch__slider');
-
-          await modeler.pause(2000);
-
-          await modeler.click('.section__body button[type="submit"]');
-
-          await modeler.pause(2000);
-
-          await modeler.setValue(VARIABLES_INPUT_SELECTOR, '{ "myVariable": 1 }');
-
-          await modeler.pause(2000);
-
-          await modeler.takeScreenshot(filepath);
-
-          return modeler;
-        }
-      )
-    },
-
-
-    {
-      skip: () => triggerScreenshot(
-        'camunda-docs/docs/components/modeler/desktop-modeler/img/start-instance-successful.png',
-        async (filepath) => {
-          const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram3.bpmn') ],
-                config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
-
-          const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
-
-          await modeler.click(START_INSTANCE_BUTTON_SELECTOR);
-
-          await modeler.click('label[for="radio-element-endpoint.targetType-camunda-8-saas"]');
-
-          await modeler.setValue('input[name="endpoint.camundaCloudClusterUrl"]', SAAS_CLUSTER_URL);
-          await modeler.setValue('input[name="endpoint.camundaCloudClientId"]', CLIENT_ID);
-          await modeler.setValue('input[name="endpoint.camundaCloudClientSecret"]', CLIENT_SECRET);
-
-          await modeler.click('div[role="dialog"] span.toggle-switch__slider');
-
-          await modeler.pause(2000);
-
-          await modeler.click('.section__body button[type="submit"]');
-
-          await modeler.pause(2000);
-
-          await modeler.setValue(VARIABLES_INPUT_SELECTOR, '{ "a": 1 }');
-
-          await modeler.click('div.section__body button.btn-primary');
-
-          await modeler.pause(2000);
-
-          await modeler.takeScreenshot(filepath);
-
-          return modeler;
-        }
-      )
-    },
-
-
-    // self-managed
-    () => triggerScreenshot(
-      'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/deploy-icon.png',
+    ()=> triggerScreenshot(
+      'camunda-docs/docs/components/modeler/desktop-modeler/img/start-instance.png',
       async (filepath) => {
-        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram2.bpmn') ],
-              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json'),
+              settingsPath = path.join(__dirname, '../fixtures/user-data/settings/default_connections.json'),
+              additionalConfig = {
+                files:{
+                  [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn')]:{
+                    'connection-manager':{
+                      connectionId: 'saas-1'
+                    }
+                  }
+                }
+              };
+        const modeler = await createModeler({ diagramPaths, configPath: config, additionalConfig, displayVersion, settingsPath });
 
-        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+        await modeler.getElement('.status-icon.success');
 
-        await modeler.mouseOver(DEPLOYMENT_BUTTON_SELECTOR);
+        await modeler.click(START_INSTANCE_BUTTON_SELECTOR);
 
-        await modeler.takeScreenshot(filepath,
-          {
-            left: 0,
-            bottom: 0,
-            width: 450,
-            height: 150
-          });
+        await modeler.setValue(VARIABLES_INPUT_SELECTOR, '{\n  "myVariable": 1\n}');
+
+        await modeler.takeScreenshot(filepath);
         return modeler;
       }
     ),
 
-    {
-      skip: () => triggerScreenshot(
-        'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/deploy-empty.png',
-        async (filepath) => {
-          const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram2.bpmn') ],
-                config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+    () => triggerScreenshot(
+      'camunda-docs/docs/components/modeler/desktop-modeler/img/start-instance-successful.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json'),
+              settingsPath = path.join(__dirname, '../fixtures/user-data/settings/default_connections.json'),
+              additionalConfig = {
+                files:{
+                  [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn')]:{
+                    'connection-manager':{
+                      connectionId: 'saas-1'
+                    }
+                  }
+                }
+              };
+        const modeler = await createModeler({ diagramPaths, configPath: config, additionalConfig, displayVersion, settingsPath });
 
-          const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+        await modeler.getElement('.status-icon.success');
 
-          await modeler.click(DEPLOYMENT_BUTTON_SELECTOR);
-          await modeler.click('label[for="radio-element-endpoint.targetType-camunda-8-self-managed"]');
+        await modeler.click(START_INSTANCE_BUTTON_SELECTOR);
 
-          await modeler.takeScreenshot(filepath);
-          return modeler;
-        }
-      )
-    },
+        await modeler.click('.section__body button[type="submit"]');
 
-    {
-      skip: () => triggerScreenshot(
-        'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/deploy-endpoint.png',
-        async (filepath) => {
-          const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram3.bpmn') ],
-                config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+        await modeler.getElement('h3:text("Process instance started")');
 
-          const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
 
-          await modeler.click(DEPLOYMENT_BUTTON_SELECTOR);
-          await modeler.click('label[for="radio-element-endpoint.targetType-camunda-8-self-managed"]');
-          await modeler.setValue('input[name="endpoint.contactPoint"]', SELF_MANAGED_CLUSTER_URL);
-
-          await modeler.takeScreenshot(filepath);
-          return modeler;
-        }
-      )
-    },
-
-    {
-      skip: () => triggerScreenshot(
-        'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/deploy-with-basic-auth.png',
-        async (filepath) => {
-          const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram3.bpmn') ],
-                config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
-
-          const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
-
-          await modeler.click(DEPLOYMENT_BUTTON_SELECTOR);
-          await modeler.click('label[for="radio-element-endpoint.targetType-camunda-8-self-managed"]');
-          await modeler.click('label[for="radio-element-endpoint.authType-basic"]');
-          await modeler.setValue('input[name="endpoint.contactPoint"]', SELF_MANAGED_CLUSTER_URL);
-          await modeler.setValue('input[name="endpoint.basicAuthUsername"]', SELF_MANAGED_BASIC_AUTH_USERNAME);
-          await modeler.setValue('input[name="endpoint.basicAuthPassword"]', SELF_MANAGED_BASIC_AUTH_PASSWORD);
-
-          await modeler.takeScreenshot(filepath);
-          return modeler;
-        }
-      )
-    },
-
-    {
-      skip: () => triggerScreenshot(
-        'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/deploy-with-oauth.png',
-        async (filepath) => {
-          const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram3.bpmn') ],
-                config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
-
-          const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
-
-          await modeler.click(DEPLOYMENT_BUTTON_SELECTOR);
-          await modeler.click('label[for="radio-element-endpoint.targetType-camunda-8-self-managed"]');
-          await modeler.click('label[for="radio-element-endpoint.authType-oauth"]');
-          await modeler.setValue('input[name="endpoint.contactPoint"]', SELF_MANAGED_CLUSTER_URL);
-          await modeler.setValue('input[name="endpoint.clientId"]', CLIENT_ID);
-          await modeler.setValue('input[name="endpoint.clientSecret"]', CLIENT_SECRET);
-          await modeler.setValue('input[name="endpoint.oauthURL"]', SELF_MANAGED_OAUTH_URL);
-          await modeler.setValue('input[name="endpoint.audience"]', SELF_MANAGED_OAUTH_AUDIENCE);
-
-          await modeler.takeScreenshot(filepath);
-          return modeler;
-        }
-      )
-    },
-
-    {
-      skip: () => triggerScreenshot(
-        'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/deploy-success.png',
-        async (filepath) => {
-          const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram3.bpmn') ],
-                config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
-
-          const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
-
-          // we deploy to SaaS here, but treat it like self-managed
-          // this way we get a self-managed deploy success notification,
-          // not a SaaS one
-          await modeler.click(DEPLOYMENT_BUTTON_SELECTOR);
-          await modeler.click('label[for="radio-element-endpoint.targetType-camunda-8-self-managed"]');
-          await modeler.click('label[for="radio-element-endpoint.authType-oauth"]');
-          await modeler.setValue('input[name="endpoint.contactPoint"]', SAAS_CLUSTER_URL);
-          await modeler.setValue('input[name="endpoint.clientId"]', CLIENT_ID);
-          await modeler.setValue('input[name="endpoint.clientSecret"]', CLIENT_SECRET);
-          await modeler.setValue('input[name="endpoint.oauthURL"]', SAAS_OAUTH_URL);
-          await modeler.setValue('input[name="endpoint.audience"]', SAAS_OAUTH_AUDIENCE);
-          await modeler.pause(5000);
-
-          await modeler.click('.section__body button[type="submit"]');
-
-          await modeler.pause(4000);
-
-          await modeler.takeScreenshot(filepath);
-          return modeler;
-        }
-      )
-    },
 
     // process applications //////////////////////
     () => triggerScreenshot(
@@ -867,8 +864,321 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
           return modeler;
         }
-      )
-    }
+      ),
+    },
 
+    // self-managed screenshots
+
+    ()=> triggerScreenshot(
+      'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/connection-selector-offline.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+
+        await modeler.mouseOver(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+
+        await modeler.takeScreenshot(filepath,
+          {
+            left: 0,
+            bottom: 0,
+            width: 500,
+            height: 250
+          });
+        return modeler;
+      }
+    ),
+
+    ()=> triggerScreenshot(
+      'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/connection-selector-offline-open.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+
+        await modeler.takeScreenshot(filepath,
+          {
+            left: 0,
+            bottom: 0,
+            width: 500,
+            height: 250
+          });
+        return modeler;
+      }
+    ),
+
+
+
+    ()=> triggerScreenshot(
+      'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/connection-manager-add.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+        await modeler.click(CONNECTION_MANAGER_BUTTON_SELECTOR);
+
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
+
+    ()=> triggerScreenshot(
+      'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/connection-selector-new-connection.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+        await modeler.click(CONNECTION_MANAGER_BUTTON_SELECTOR);
+        await modeler.click('button:text("Add connection")');
+
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].name"]', 'New Connection');
+        await modeler.click('label[for="radio-element-connectionManagerPlugin.c8connections[2].targetType-camunda-8-self-managed"]');
+        await modeler.click('label[for="radio-element-connectionManagerPlugin.c8connections[2].authType-oauth"]');
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].contactPoint"]', SELF_MANAGED_CLUSTER_URL);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].clientId"]', CLIENT_ID);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].clientSecret"]', CLIENT_SECRET);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].oauthURL"]', SELF_MANAGED_OAUTH_URL);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].audience"]', SELF_MANAGED_OAUTH_AUDIENCE);
+
+        await modeler.click('button:text("Done")');
+        await modeler.pause(500);
+
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+
+        await modeler.takeScreenshot(filepath,
+          {
+            left: 0,
+            bottom: 0,
+            width: 400,
+            height: 300
+          });
+        return modeler;
+      }
+    ),
+
+    ()=> triggerScreenshot(
+      'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/connection-with-sm.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+        await modeler.click(CONNECTION_MANAGER_BUTTON_SELECTOR);
+        await modeler.click('button:text("Add connection")');
+
+        await modeler.click('label[for="radio-element-connectionManagerPlugin.c8connections[2].targetType-camunda-8-self-managed"]');
+
+        await modeler.scrollIntoViewIfNeeded('label[for="radio-element-connectionManagerPlugin.c8connections[2].targetType-camunda-8-self-managed"]');
+
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
+
+    ()=> triggerScreenshot(
+      'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/connection-with-basic-auth.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+        await modeler.click(CONNECTION_MANAGER_BUTTON_SELECTOR);
+        await modeler.click('button:text("Add connection")');
+
+        await modeler.click('label[for="radio-element-connectionManagerPlugin.c8connections[2].targetType-camunda-8-self-managed"]');
+        await modeler.click('label[for="radio-element-connectionManagerPlugin.c8connections[2].authType-basic"]');
+
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].contactPoint"]', SELF_MANAGED_CLUSTER_URL);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].basicAuthUsername"]', SELF_MANAGED_BASIC_AUTH_USERNAME);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].basicAuthPassword"]', SELF_MANAGED_BASIC_AUTH_PASSWORD);
+
+        await modeler.scrollIntoViewIfNeeded('input[name="connectionManagerPlugin.c8connections[2].basicAuthPassword"]');
+
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
+
+    ()=> triggerScreenshot(
+      'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/connection-with-endpoint.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+        await modeler.click(CONNECTION_MANAGER_BUTTON_SELECTOR);
+        await modeler.click('button:text("Add connection")');
+
+        await modeler.click('label[for="radio-element-connectionManagerPlugin.c8connections[2].targetType-camunda-8-self-managed"]');
+
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].contactPoint"]', SELF_MANAGED_CLUSTER_URL);
+
+        await modeler.scrollIntoViewIfNeeded('input[name="connectionManagerPlugin.c8connections[2].contactPoint"]');
+
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
+
+    ()=> triggerScreenshot(
+      'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/connection-with-oauth.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
+
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+        await modeler.click(CONNECTION_MANAGER_BUTTON_SELECTOR);
+        await modeler.click('button:text("Add connection")');
+
+        await modeler.click('label[for="radio-element-connectionManagerPlugin.c8connections[2].targetType-camunda-8-self-managed"]');
+        await modeler.click('label[for="radio-element-connectionManagerPlugin.c8connections[2].authType-oauth"]');
+
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].clientId"]', CLIENT_ID);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].clientSecret"]', CLIENT_SECRET);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].oauthURL"]', SELF_MANAGED_OAUTH_URL);
+        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].audience"]', SELF_MANAGED_OAUTH_AUDIENCE);
+
+        await modeler.scrollIntoViewIfNeeded('input[name="connectionManagerPlugin.c8connections[2].scope"]');
+
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
+
+    () => triggerScreenshot(
+      'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/deploy-selection.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json'),
+              settingsPath = path.join(__dirname, '../fixtures/user-data/settings/default_connections.json'),
+              additionalConfig = {
+                files:{
+                  [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn')]:{
+                    'connection-manager':{
+                      connectionId: 'saas-1'
+                    }
+                  }
+                }
+              };
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, additionalConfig, displayVersion, settingsPath });
+
+        await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+
+        await modeler.getElement('.status-icon.success');
+
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
+
+    () => triggerScreenshot(
+      'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/deploy-icon.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json'),
+              settingsPath = path.join(__dirname, '../fixtures/user-data/settings/default_connections.json'),
+              additionalConfig = {
+                files:{
+                  [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn')]:{
+                    'connection-manager':{
+                      connectionId: 'saas-1'
+                    }
+                  }
+                }
+              };
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, additionalConfig, displayVersion, settingsPath });
+
+        await modeler.mouseOver(DEPLOYMENT_BUTTON_SELECTOR);
+
+        await modeler.getElement('.status-icon.success');
+
+        await modeler.takeScreenshot(filepath,
+          {
+            left: 0,
+            bottom: 0,
+            width: 500,
+            height: 200
+          });
+        return modeler;
+      }
+    ),
+
+    () => triggerScreenshot(
+      'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/deploy-diagram.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json'),
+              settingsPath = path.join(__dirname, '../fixtures/user-data/settings/default_connections.json'),
+              additionalConfig = {
+                files:{
+                  [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn')]:{
+                    'connection-manager':{
+                      connectionId: 'saas-1'
+                    }
+                  }
+                }
+              };
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, additionalConfig, displayVersion, settingsPath });
+
+        await modeler.getElement('.status-icon.success');
+
+        await modeler.click(DEPLOYMENT_BUTTON_SELECTOR);
+
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    ),
+
+    () => triggerScreenshot(
+      'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/deploy-success.png',
+      async (filepath) => {
+        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json'),
+              settingsPath = path.join(__dirname, '../fixtures/user-data/settings/default_connections.json'),
+              additionalConfig = {
+                files:{
+                  [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn')]:{
+                    'connection-manager':{
+                      connectionId: 'saas-1'
+                    }
+                  }
+                }
+              };
+
+        const modeler = await createModeler({ diagramPaths, configPath: config, additionalConfig, displayVersion, settingsPath });
+
+        await modeler.getElement('.status-icon.success');
+
+        await modeler.click(DEPLOYMENT_BUTTON_SELECTOR);
+
+        await modeler.click('.section__body button[type="submit"]');
+
+        await modeler.getElement('h3:text("Process definition deployed")');
+
+        await modeler.takeScreenshot(filepath);
+        return modeler;
+      }
+    )
   ];
 };

--- a/lib/fixtures/bpmn/cloud-reference/quickstart.bpmn
+++ b/lib/fixtures/bpmn/cloud-reference/quickstart.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0eyysa7" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.46.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <bpmn:process id="Process_0h11kbu" name="Quick Start" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1crfeeu</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1crfeeu" sourceRef="StartEvent_1" targetRef="serviceTask_1" />
+    <bpmn:endEvent id="Event_1bwwwx5">
+      <bpmn:incoming>Flow_0tfxrdb</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0tfxrdb" sourceRef="serviceTask_1" targetRef="Event_1bwwwx5" />
+    <bpmn:serviceTask id="serviceTask_1" name="My Service Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="myCustomDefinition" retries="3" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1crfeeu</bpmn:incoming>
+      <bpmn:outgoing>Flow_0tfxrdb</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0h11kbu">
+      <bpmndi:BPMNEdge id="Flow_0tfxrdb_di" bpmnElement="Flow_0tfxrdb">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1crfeeu_di" bpmnElement="Flow_1crfeeu">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1bwwwx5_di" bpmnElement="Event_1bwwwx5">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0iaadld_di" bpmnElement="serviceTask_1">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/lib/fixtures/user-data/quickstart_with_prop_panel_c8run.json
+++ b/lib/fixtures/user-data/quickstart_with_prop_panel_c8run.json
@@ -1,0 +1,33 @@
+{
+  "workspace": {
+    "endpoints": [],
+    "layout": {
+      "dmnOverview": {
+        "open": false
+      },
+      "log": {
+        "open": false
+      },
+      "propertiesPanel": {
+        "open": true,
+        "width": 420,
+        "groups": {
+          "ElementTemplates__CustomProperties": {
+            "open": true
+          }
+        }
+      }
+    }
+  },
+  "lastUsedConnection": "c8run",
+  "window": {
+    "fullScreen": false,
+    "maximize": false,
+    "bounds": {
+      "x": 0,
+      "y": 0,
+      "width": 1200,
+      "height": 700
+    }
+  }
+}

--- a/lib/fixtures/user-data/settings/c8run_connection.json
+++ b/lib/fixtures/user-data/settings/c8run_connection.json
@@ -1,0 +1,12 @@
+{
+  "connectionManagerPlugin.c8connections": [
+    {
+      "id": "c8run",
+      "name": "c8run (local)",
+      "contactPoint": "http://localhost:8080/v2",
+      "operateUrl": "http://localhost:8080/operate",
+      "targetType": "selfHosted",
+      "authType": "none"
+    }
+  ]
+}

--- a/lib/fixtures/user-data/settings/default_connections.json
+++ b/lib/fixtures/user-data/settings/default_connections.json
@@ -1,0 +1,21 @@
+{
+  "connectionManagerPlugin.c8connections": [
+    {
+      "id": "saas-1",
+      "name": "Dev Cluster",
+      "targetType": "camundaCloud",
+      "camundaCloudClusterUrl": "SECRET_CLUSTER_URL",
+      "contactPoint": "SECRET_CLUSTER_URL",
+      "camundaCloudClientId": "SECRET_CLIENT_ID",
+      "camundaCloudClientSecret": "SECRET_CLIENT_SECRET"
+    },
+    {
+      "id": "c8run",
+      "name": "c8run (local)",
+      "contactPoint": "http://localhost:8080/v2",
+      "operateUrl": "http://localhost:8080/operate",
+      "targetType": "selfHosted",
+      "authType": "none"
+    }
+  ]
+}

--- a/lib/helper/createModeler.js
+++ b/lib/helper/createModeler.js
@@ -22,13 +22,15 @@ class Modeler {
     diagramPaths = [],
     configPath,
     additionalConfig = {},
+    settingsPath = path.join(__dirname, '../fixtures/user-data/settings/default_connections.json'),
+    additionalSettings = {},
     elementTemplatePaths = [],
     processApplicationPaths = [],
     displayVersion
   } = {}) {
     this._ensureTempDirectory();
 
-    this._tmpUserDataPath = copyUserData(configPath, additionalConfig);
+    this._tmpUserDataPath = copyUserData(configPath, additionalConfig, settingsPath, additionalSettings);
 
     this._tmpFilePaths = copyTemporaryFiles([
       ...diagramPaths,
@@ -82,7 +84,7 @@ class Modeler {
   }
 
   async getElement(selector) {
-    await this.window.waitForSelector(selector);
+    await this.window.waitForSelector(selector, { state: 'attached' });
     const element = await this.window.locator(selector).first();
     return element;
   }
@@ -93,7 +95,14 @@ class Modeler {
 
   async rightClick(selector) {
     await this.window.click(selector, { button: 'right', force: true });
+  }
 
+  async scrollIntoViewIfNeeded(selector) {
+    const element = await this.getElement(selector);
+    if (!element) {
+      return;
+    }
+    await element.scrollIntoViewIfNeeded();
   }
 
   async doubleClick(selector) {
@@ -203,7 +212,7 @@ class Modeler {
  * @param {string?} [config.configPath]
  * @param {string?} [config.displayVersion]
  *
- * @returns {Modeler}
+ * @returns {Promise<Modeler>}
  */
 async function createModeler(config) {
   const modeler = new Modeler(config);
@@ -270,7 +279,7 @@ function copyTemporaryFiles(filePaths = []) {
  *
  * @returns {string} path to the user directory
  */
-function copyUserData(configPath, additionalConfig) {
+function copyUserData(configPath, additionalConfig, settingsPath, additionalSettings) {
 
   fs.mkdirSync(path.join(__dirname, '../tmp/workspace'), { recursive: true });
 
@@ -287,9 +296,33 @@ function copyUserData(configPath, additionalConfig) {
   fs.writeFileSync(path.join(basePath, 'config.json'), JSON.stringify(config, null, 2));
   fs.copyFileSync(flagsPath, path.join(basePath, 'resources', 'flags.json'));
 
+  if (settingsPath) {
+    const settings = injectEnvSecrets(JSON.parse(fs.readFileSync(settingsPath, 'utf8')));
+    fs.writeFileSync(path.join(basePath, 'settings.json'), JSON.stringify({ ...settings, ...additionalSettings }, null, 2));
+  }
+
   return basePath;
 }
 
+
+const SECRET_PREFIX = 'SECRET_';
+
+function injectEnvSecrets(value) {
+  if (typeof value === 'string' && value.startsWith(SECRET_PREFIX)) {
+    const envKey = value.slice(SECRET_PREFIX.length);
+    return Object.prototype.hasOwnProperty.call(process.env, envKey) ? process.env[envKey] : value;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(injectEnvSecrets);
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([ k, v ]) => [ k, injectEnvSecrets(v) ]));
+  }
+  return value;
+}
 
 function copyElementTemplates(elementTemplatePaths = [], pathToUserData) {
   const TEMPLATE_PATH = path.join(`${pathToUserData}/resources/element-templates`);

--- a/lib/takeScreenshots.js
+++ b/lib/takeScreenshots.js
@@ -36,6 +36,8 @@ async function runAll(displayVersion) {
    */
   const notSkippedTasks = actualTasks.filter(t => !t.skip);
 
+
+
   await pAll(notSkippedTasks, { concurrency, stopOnError });
 
   await killModelerInstances();


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-docs-modeler-screenshots/issues/128

- Automates screenshots for connection manager
- adjusts previously skipped screenshots to work again
- settings can now be injected (including injecting secrets from ENV)
- helper scrollIntoViewIfNeeded
- 
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
