### PR TITLE
support defining displayVersion for all tasks

### DIFF
--- a/lib/camunda-docs-manual/modeler.js
+++ b/lib/camunda-docs-manual/modeler.js
@@ -5,14 +5,14 @@ const path = require('path');
 
 const { triggerScreenshot } = require('../helper/screenshotUtil');
 
-module.exports = function startScreenshotBatch() {
+module.exports = function startScreenshotBatch(displayVersion) {
 
   return [
     () => triggerScreenshot('camunda-docs-manual/content/modeler/img/history-time-to-live.png', async (filepath) => {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/history-time-to-live/info.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[title="Toggle problems view"]');
 

--- a/lib/camunda-docs-manual/userGuide.js
+++ b/lib/camunda-docs-manual/userGuide.js
@@ -11,7 +11,7 @@ const annotationOptions = {
 };
 
 
-module.exports = function startScreenshotBatch() {
+module.exports = function startScreenshotBatch(displayVersion) {
 
   return [
 
@@ -19,7 +19,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/show_form.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/large_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="Activity_0qkkllp"]');
 
@@ -34,7 +34,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/show_form.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/large_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="Activity_0qkkllp"]');
 
@@ -57,7 +57,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/show_form.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/large_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[title="Deploy current diagram"]');
 

--- a/lib/camunda-docs-manual/webapps.js
+++ b/lib/camunda-docs-manual/webapps.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { triggerScreenshot } = require('../helper/screenshotUtil');
 
 
-module.exports = function startScreenshotBatch() {
+module.exports = function startScreenshotBatch(displayVersion) {
 
   return [
 
@@ -12,7 +12,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/invoice.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/large_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="approveInvoice"]');
 

--- a/lib/camunda-docs-static/quickstart.js
+++ b/lib/camunda-docs-static/quickstart.js
@@ -10,7 +10,7 @@ const annotationOptions = {
   left: { x: -50, y: 0 }
 };
 
-module.exports = function startScreenshotBatch() {
+module.exports = function startScreenshotBatch(displayVersion) {
 
   return [
 
@@ -19,7 +19,7 @@ module.exports = function startScreenshotBatch() {
       async (filepath) => {
         const config = path.join(__dirname, '../fixtures/user-data/quickstart_large_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths: [], configPath: config });
+        const modeler = await createModeler({ diagramPaths: [], configPath: config, displayVersion });
 
         await modeler.click('[title="Create new ..."]');
         await modeler.mouseOver('[role="dialog"] [title="BPMN diagram"]');
@@ -35,7 +35,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step1.1.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="StartEvent_1"]');
 
@@ -53,7 +53,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step1.2.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="serviceTask1"]');
         await modeler.click('[data-action="replace"]');
@@ -72,7 +72,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step1.3.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="endEvent1"]');
 
@@ -89,7 +89,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step1.3.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_no_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="serviceTask1"]');
         await modeler.annotate('.editor .resizer-left > svg', "If it\\'s not already visible, click \\n on the <b>Properties Panel toggle</b>", annotationOptions.left);
@@ -105,7 +105,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step1.3.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-group-id="group-general"]');
 
@@ -124,7 +124,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step1.3.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.mouseOver('button[title="Deploy current diagram"]');
 
@@ -145,7 +145,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step1.3.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('button[title="Deploy current diagram"]');
 
@@ -166,7 +166,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step1.3.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('button[title="Deploy current diagram"]');
 
@@ -189,7 +189,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step2.1.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.annotate(
           '[data-action="create.task"]',
@@ -210,7 +210,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step2.1.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="userTask"]');
         await modeler.click('[data-action="replace"]');
@@ -227,7 +227,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step2.2.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/large_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="userTask"]');
         await modeler.click('[data-group-id="group-CamundaPlatform__UserAssignment"]');
@@ -250,7 +250,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step2.2.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="userTask"]');
         await modeler.click('[data-group-id="group-CamundaPlatform__Form"]');
@@ -267,7 +267,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step2.3.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_large_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="userTask"]');
         await modeler.click('[data-tab-target="forms"]');
@@ -284,7 +284,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step2.3.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_large_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="userTask"]');
         await modeler.click('[data-tab-target="forms"]');
@@ -301,7 +301,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step2.3.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_large_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="userTask"]');
         await modeler.click('[data-tab-target="forms"]');
@@ -317,7 +317,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step3.1.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.annotate('[data-action="create.exclusive-gateway"]', 'Gateway', annotationOptions.right);
 
@@ -331,7 +331,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step3.2.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-group-id="group-general"]');
 
@@ -345,7 +345,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step3.2.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/large_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="SequenceFlow_0ilu8bp"]');
 
@@ -368,7 +368,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step3.2.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         // The actual sequence flow is not clickable in the middle of the Bounding Box, so we use the label
         await modeler.click('[data-element-id="SequenceFlow_0di0jwo_label"]');
@@ -386,7 +386,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step3.2.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="SequenceFlow_187qbq7_label"]');
 
@@ -403,7 +403,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step3.2.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="SequenceFlow_0ypgah8_label"]');
 
@@ -420,7 +420,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step3.2.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="userTask"]');
         await modeler.click('[data-action="replace"]');
@@ -436,7 +436,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/quickstart/step4.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/large_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="Task_1j42goo"]');
 
@@ -458,7 +458,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/dmn/quickstart/step4.2.dmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="approve-payment"]');
 
@@ -493,7 +493,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/dmn/quickstart/step4.2.dmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-element-id="approve-payment"]');
 
@@ -512,7 +512,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/dmn/quickstart/step4.1.dmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-container-id="approve-payment"] .drill-down-overlay');
         await modeler.doubleClick('.input-expression');
@@ -535,7 +535,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/dmn/quickstart/step4.2.dmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-container-id="approve-payment"] .drill-down-overlay');
 
@@ -550,7 +550,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/dmn/quickstart/step4.2.dmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-container-id="approve-payment"] .drill-down-overlay');
 
@@ -564,7 +564,7 @@ module.exports = function startScreenshotBatch() {
         const diagramPaths = [ path.join(__dirname, '../fixtures/dmn/quickstart/step4.2.dmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
-        const modeler = await createModeler({ diagramPaths, configPath: config });
+        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
         await modeler.click('[data-container-id="approve-payment"] .drill-down-overlay');
         await modeler.click('.app-icon-deploy');

--- a/lib/camunda-docs/modelingGuidance.js
+++ b/lib/camunda-docs/modelingGuidance.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 const { triggerScreenshot } = require('../helper/screenshotUtil');
 
-module.exports = function startScreenshotBatch() {
+module.exports = function startScreenshotBatch(displayVersion) {
 
   return [
 
@@ -13,7 +13,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/called-element/wrong.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="CallActivity_1"]');
 
@@ -30,7 +30,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/called-element/right.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="CallActivity_1"]');
 
@@ -47,7 +47,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/element-type/wrong.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="Task_1"]');
 
@@ -62,7 +62,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/element-type/right.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="Task_1"]');
 
@@ -77,7 +77,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/error-reference/wrong-no-error-reference.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="ErrorBoundaryEvent_1"]');
 
@@ -94,7 +94,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/error-reference/wrong-no-error-code.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="ErrorBoundaryEvent_1"]');
 
@@ -111,7 +111,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/error-reference/right.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="ErrorBoundaryEvent_1"]');
 
@@ -128,7 +128,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/escalation-reference/wrong-no-escalation-reference.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="EscalationEndEvent_1"]');
 
@@ -145,7 +145,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/escalation-reference/wrong-no-escalation-code.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="EscalationEndEvent_1"]');
 
@@ -162,7 +162,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/escalation-reference/right.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="EscalationEndEvent_1"]');
 
@@ -179,7 +179,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/feel/wrong.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="ServiceTask_1"]');
 
@@ -196,7 +196,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/feel/right.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="ServiceTask_1"]');
 
@@ -213,7 +213,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/message-reference/wrong-no-message-reference.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="MessageBoundaryEvent_1"]');
 
@@ -230,7 +230,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/message-reference/right.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[data-element-id="MessageBoundaryEvent_1"]');
 
@@ -247,7 +247,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/no-loop/wrong.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[title="Toggle problems view"]');
 
@@ -262,7 +262,7 @@ module.exports = function startScreenshotBatch() {
       const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/modeling-guidance/no-loop/right.bpmn') ],
             config = path.join(__dirname, '../fixtures/user-data/small_with_prop_panel.json');
 
-      const modeler = await createModeler({ diagramPaths, configPath: config });
+      const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
       await modeler.click('[title="Toggle problems view"]');
 

--- a/lib/takeScreenshots.js
+++ b/lib/takeScreenshots.js
@@ -15,11 +15,11 @@ async function runAll(displayVersion) {
 
   const tasks = [
     cloudReference(displayVersion),
-    quickstart(),
-    userGuide(),
-    webapps(),
-    modelingGuidance(),
-    modelerC7()
+    quickstart(displayVersion),
+    userGuide(displayVersion),
+    webapps(displayVersion),
+    modelingGuidance(displayVersion),
+    modelerC7(displayVersion)
   ].flat();
 
   /**


### PR DESCRIPTION
Before the displayVersion flag only affected a subset of screenshots. Now I copied the logic to all triggerScreenshots functions

Why?
- allows generating screenshots even from RC builds without the rc noise
- enables version pinning -> eg if same version is specified only the actual changes are easier to see (eg git diff)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
