### PR TITLE
fix: adjust variables input selector

### DIFF
--- a/lib/camunda-docs/cloudReference.js
+++ b/lib/camunda-docs/cloudReference.js
@@ -27,7 +27,7 @@ const DEPLOYMENT_BUTTON_SELECTOR = 'button[title="Open file deployment"]';
 const START_INSTANCE_BUTTON_SELECTOR = 'button[title="Open start instance"]';
 const TASK_TESTING_BUTTON_SELECTOR = 'button[title="Toggle test view"]';
 
-const VARIABLES_INPUT_SELECTOR = '.cm-content';
+const VARIABLES_INPUT_SELECTOR = '[role="dialog"] .cm-content';
 
 module.exports = function startScreenshotBatch(displayVersion) {
 


### PR DESCRIPTION
Adjusted the variables input selector to be more specific and target the "Start BPMN process instance" popup. Previously, it resolved to the first CodeMirror editor on the page, which broke the screenshot generation.