### PR TITLE
fix: fix screenshots issues

### DIFF
--- a/lib/camunda-docs/cloudReference.js
+++ b/lib/camunda-docs/cloudReference.js
@@ -49,7 +49,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
       'camunda-docs/docs/components/modeler/desktop-modeler/img/new-diagram.png',
       async (filepath) => {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/diagram1.bpmn') ],
-              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop+var_panel.json');
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
 
         const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
@@ -130,7 +130,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
       'camunda-docs/docs/components/modeler/desktop-modeler/img/connection-selector-offline-open.png',
       async (filepath) => {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
-              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_no_prop_panel.json');
 
         const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
@@ -355,6 +355,9 @@ module.exports = function startScreenshotBatch(displayVersion) {
         await modeler.click('.section__body button[type="submit"]');
 
         await modeler.getElement('h3:text("Process definition deployed")');
+
+        // wait for animation to finish
+        await modeler.pause(500);
 
         await modeler.takeScreenshot(filepath);
         return modeler;
@@ -582,6 +585,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
         const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion, elementTemplatePaths: templates });
 
         await modeler.click('[data-element-id="ServiceTask_1"]');
+        await modeler.getElement('button[title="Select a template"]');
         await modeler.click('button[title="Select a template"]');
 
         await modeler.takeScreenshot(filepath);
@@ -688,24 +692,6 @@ module.exports = function startScreenshotBatch(displayVersion) {
       async (filepath) => {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/element-templates/icon.bpmn') ],
               config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json'),
-              templates = [ path.join(__dirname, '../fixtures/element-templates/all-templates.json') ];
-
-
-        const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion, elementTemplatePaths: templates });
-
-        await modeler.click('[data-element-id="ServiceTask_1"]');
-
-        await modeler.takeScreenshot(filepath);
-
-        return modeler;
-      }
-    ),
-
-    () => triggerScreenshot(
-      'camunda-docs/docs/components/modeler/element-templates/img/entries-visible.png',
-      async (filepath) => {
-        const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/element-templates/entries-visible.bpmn') ],
-              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel_entries_visible.json'),
               templates = [ path.join(__dirname, '../fixtures/element-templates/all-templates.json') ];
 
 
@@ -894,7 +880,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
       'camunda-docs/docs/self-managed/components/modeler/desktop-modeler/img/connection-selector-offline-open.png',
       async (filepath) => {
         const diagramPaths = [ path.join(__dirname, '../fixtures/bpmn/cloud-reference/quickstart.bpmn') ],
-              config = path.join(__dirname, '../fixtures/user-data/quickstart_with_prop_panel.json');
+              config = path.join(__dirname, '../fixtures/user-data/quickstart_no_prop_panel.json');
 
         const modeler = await createModeler({ diagramPaths, configPath: config, displayVersion });
 
@@ -923,6 +909,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
         await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
         await modeler.click(CONNECTION_MANAGER_BUTTON_SELECTOR);
+        await modeler.scrollIntoViewIfNeeded('button:text("Add connection")');
 
         await modeler.takeScreenshot(filepath);
         return modeler;
@@ -941,7 +928,6 @@ module.exports = function startScreenshotBatch(displayVersion) {
         await modeler.click(CONNECTION_MANAGER_BUTTON_SELECTOR);
         await modeler.click('button:text("Add connection")');
 
-        await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].name"]', 'New Connection');
         await modeler.click('label[for="radio-element-connectionManagerPlugin.c8connections[2].targetType-camunda-8-self-managed"]');
         await modeler.click('label[for="radio-element-connectionManagerPlugin.c8connections[2].authType-oauth"]');
         await modeler.setValue('input[name="connectionManagerPlugin.c8connections[2].contactPoint"]', SELF_MANAGED_CLUSTER_URL);
@@ -954,12 +940,13 @@ module.exports = function startScreenshotBatch(displayVersion) {
         await modeler.pause(500);
 
         await modeler.click(CONNECTION_SELECTOR_BUTTON_SELECTOR);
+        await modeler.window.selectOption('select#connection', { label: 'New connection 3' });
 
         await modeler.takeScreenshot(filepath,
           {
             left: 0,
             bottom: 0,
-            width: 400,
+            width: 500,
             height: 300
           });
         return modeler;
@@ -1175,6 +1162,9 @@ module.exports = function startScreenshotBatch(displayVersion) {
         await modeler.click('.section__body button[type="submit"]');
 
         await modeler.getElement('h3:text("Process definition deployed")');
+
+        // wait for animation to finish
+        await modeler.pause(500);
 
         await modeler.takeScreenshot(filepath);
         return modeler;

--- a/lib/camunda-docs/modelingGuidance.js
+++ b/lib/camunda-docs/modelingGuidance.js
@@ -36,6 +36,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
       await modeler.click('[title="Toggle problems view"]');
 
+      await modeler.getElement('.bio-properties-panel-group-header-title >> "Called element"');
       await modeler.click('.bio-properties-panel-group-header-title >> "Called element"');
 
       await modeler.takeScreenshot(filepath);
@@ -119,6 +120,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
       await modeler.click('[title="Toggle problems view"]');
 
+      await modeler.getElement('.bio-properties-panel-group-header-title >> "Error"');
       await modeler.click('.bio-properties-panel-group-header-title >> "Error"');
 
       await modeler.takeScreenshot(filepath);
@@ -172,6 +174,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
       await modeler.click('[title="Toggle problems view"]');
 
+      await modeler.getElement('.bio-properties-panel-group-header-title >> "Escalation"');
       await modeler.click('.bio-properties-panel-group-header-title >> "Escalation"');
 
       await modeler.takeScreenshot(filepath);
@@ -206,6 +209,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
       await modeler.click('[title="Toggle problems view"]');
 
+      await modeler.getElement('.bio-properties-panel-group-header-title >> "Task definition"');
       await modeler.click('.bio-properties-panel-group-header-title >> "Task definition"');
 
       await modeler.takeScreenshot(filepath);
@@ -240,6 +244,7 @@ module.exports = function startScreenshotBatch(displayVersion) {
 
       await modeler.click('[title="Toggle problems view"]');
 
+      await modeler.getElement('.bio-properties-panel-group-header-title >> "Message"');
       await modeler.click('.bio-properties-panel-group-header-title >> "Message"');
 
       await modeler.takeScreenshot(filepath);


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-docs-modeler-screenshots/issues/157

Fix the screenshot issues:

- modeler/deploy-diagram-success.png, modeler/deploy-success.png: Need to wait for the notification animation to finish.
- modeler/connection-selector-offline-open.png - no need for the properties panel to be open
- modeler/deploy-diagram.png, self-managed/deploy-diagram.png - fix the warning in problems panel
- desktop-modeler/new-diagram.png - no need for the variable panel to be open
- self-managed/connection-manager-add.png: Need to scroll to the 'Add connection' button.
- self-managed/connection-selector-new-connection.png: Wrong cluster selected. It should be 'New connection 3'.
- entries-visible.png: Remove this screenshot, it is no longer needed.

Additionally, fixed some flaky tests by adding an assertion to wait until the element appears.

 Artifacts could be download [here](https://github.com/camunda/camunda-docs-modeler-screenshots/actions/runs/26109902350).

Fixed screenshots:

modeler/deploy-diagram-success.png
<img width="1200" height="673" alt="image" src="https://github.com/user-attachments/assets/5b8f5e5b-f7fa-4751-8244-aa1c158fc37d" />


modeler/deploy-success.png
<img width="1200" height="673" alt="image" src="https://github.com/user-attachments/assets/63575678-9883-470c-94cd-605bcfd06159" />


modeler/connection-selector-offline-open.png
<img width="1200" height="673" alt="image" src="https://github.com/user-attachments/assets/53fc6dd9-e8ea-4524-89ce-8f23dd41629e" />


modeler/deploy-diagram.png, self-managed/deploy-diagram.png
<img width="1200" height="673" alt="image" src="https://github.com/user-attachments/assets/e03169f2-5894-4141-b570-6ecd7ea4e06f" />

desktop-modeler/new-diagram.png
<img width="1200" height="673" alt="image" src="https://github.com/user-attachments/assets/b2139294-d5e7-46ec-8ffc-91013b552cc6" />

self-managed/connection-manager-add.png
<img width="1200" height="673" alt="image" src="https://github.com/user-attachments/assets/4b11b1b4-6935-44e0-ab6d-8aa4158909e8" />

self-managed/connection-selector-new-connection.png
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/97d5c796-8e35-47d4-a39d-0f01b1a5680a" />

 
